### PR TITLE
chore(lint): ignore package json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.6.1/schema.json",
   "files": {
-    "ignore": ["dist/*"]
+    "ignore": ["dist/*", "package.json"]
   },
   "organizeImports": {
     "enabled": true


### PR DESCRIPTION
*release-please* reformats the package.json when it bumps the version wich leads to linting/formatting errors. preferably, I would get *release-please* to **only** bump the version and not do any formatting changes but I couldn't figure out how to do that yet.