### PR TITLE
fix: improved jira key extraction from branch name

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -151,6 +151,6 @@ const buildTicketUrl = (
   );
 
 function extractJiraKey(branchName: string): Option.Option<string> {
-  const res = branchName.match(/^(?:\w+\/)?((?:[a-z]+-)?\d+)/i);
+  const res = branchName.match(/^(?:\w+\/)?([A-Z]+-\d+)/);
   return Option.fromNullable(res?.[1]);
 }


### PR DESCRIPTION
this commit makes the jira key extraction more specific. we now expect a jira project (e.g. 'GCJB-') to exist in the branch and the project to be in all uppercase letters.