### PR TITLE
feat: base existing branch matches only on their jira key

### DIFF
--- a/test/core.spec.ts
+++ b/test/core.spec.ts
@@ -216,10 +216,6 @@ describe('core', () => {
         );
 
         expect(mockAppConfigService.getAppConfig).toHaveBeenCalledTimes(1);
-        expect(mockJiraClient.getJiraIssue).toHaveBeenCalledTimes(1);
-        expect(mockJiraClient.getJiraIssue).toHaveBeenCalledWith(
-          'DUMMYAPP-123',
-        );
         expect(mockGitClient.createGitBranch).toHaveBeenCalledTimes(1);
         expect(mockGitClient.createGitBranch).toHaveBeenCalledWith(
           'feat/DUMMYAPP-123-dummy-isssue-summary',
@@ -301,10 +297,6 @@ describe('core', () => {
         `);
 
         expect(mockAppConfigService.getAppConfig).toHaveBeenCalledTimes(1);
-        expect(mockJiraClient.getJiraIssue).toHaveBeenCalledTimes(1);
-        expect(mockJiraClient.getJiraIssue).toHaveBeenCalledWith(
-          'DUMMYAPP-123',
-        );
         expect(mockGitClient.listBranches).toHaveBeenCalledTimes(1);
         expect(mockGitClient.switchBranch).toHaveBeenCalledTimes(1);
         expect(mockGitClient.switchBranch).toHaveBeenCalledWith(


### PR DESCRIPTION
previously the branch name had to *exactly* match the name that this tool would have chosen for the branch. relaxing this allows to also work with branches that have been manually created for a ticket - or when the summary in jira was modified after the branch was created.