### PR TITLE
feat!: prevent create command from switching branches

### DIFF
--- a/e2e-test/git-jira-branch.spec.ts
+++ b/e2e-test/git-jira-branch.spec.ts
@@ -71,20 +71,22 @@ describe('git-jira-branch', () => {
     );
   });
 
-  it('create subcommand switches to already existing branch for existing jira ticket', async () => {
-    const res = runApp(tmpDir, 'create', 'GCJB-1');
+  it('create subcommand fails for already existing branch', async () => {
+    try {
+      runApp(tmpDir, 'create', 'GCJB-1');
+      expect.unreachable('Should have thrown');
+      // biome-ignore lint/suspicious/noExplicitAny: any is okay in this test
+    } catch (error: any) {
+      expect(error?.stdout.toString()).toMatchInlineSnapshot(`
+        "[0;31mA branch for ticket 'GCJB-1' already exists: feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary[0m
 
-    expect(res).toMatchInlineSnapshot(`
-      "Switched to already existing branch: 'feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary'
-      "
-    `);
-    expect(currentBranch(tmpDir)).toMatchInlineSnapshot(
-      '"feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary"',
-    );
+        "
+      `);
+      return;
+    }
   });
 
   it('create subcommand resets branch to given base ref', () => {
-    runApp(tmpDir, 'create', 'GCJB-1');
     expect(currentBranch(tmpDir)).toMatchInlineSnapshot(
       '"feat/GCJB-1-e2e-test-ticket-with-a-fancy-summary"',
     );

--- a/src/core.ts
+++ b/src/core.ts
@@ -36,8 +36,11 @@ export const gitCreateJiraBranch = (
     const associatedBranch = yield* getAssociatedBranch(fullJiraKey);
 
     if (!reset && Option.isSome(associatedBranch)) {
-      yield* gitClient.switchBranch(associatedBranch.value.name);
-      return SwitchedBranch({branch: associatedBranch.value.name});
+      yield* Effect.fail(
+        UsageError({
+          message: `A branch for ticket '${fullJiraKey}' already exists: ${associatedBranch.value.name}`,
+        }),
+      );
     }
 
     const branchName = yield* pipe(


### PR DESCRIPTION
BREAKING-CHANGE: The create command was previously responsible for creating and switching branches. To prevent accidentally switching to an existing branch or accidentally creating a new one when switching was intended the new `switch` command was added in v1.4. This command should be used from now on. `create` will only create new branches and fail if a brach associated with the given ticket already exists (unless `--reset` is given)