### PR TITLE
feat(create-command): add `type` option for custom branch types

### DIFF
--- a/.github/actions/setup-node-and-pnpm-dependencies/action.yml
+++ b/.github/actions/setup-node-and-pnpm-dependencies/action.yml
@@ -1,13 +1,17 @@
-name: 'Setup node, pnpm and dependencies'
+name: "Setup node, pnpm and dependencies"
 inputs:
   node-version:
-    description: 'Node version to use'
+    description: "Node version to use"
     required: true
     default: 20
   runner-os:
-    description: 'Runner os to use'
+    description: "Runner os to use"
     required: true
-    default: 'ubuntu-latest'
+    default: "ubuntu-latest"
+  cache:
+    description: "Cache to use"
+    required: true
+    default: "pnpm"
 runs:
   using: "composite"
   steps:
@@ -20,8 +24,8 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-        cache: pnpm
+        registry-url: "https://registry.npmjs.org"
+        cache: ${{ inputs.cache }}
     - name: Install dependencies
       run: pnpm i
       shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           runner-os: ${{ matrix.os }}
+          cache: ''
       - name: Build
         run: pnpm build
       - name: Pack

--- a/e2e-test/__snapshots__/info.spec.ts.snap
+++ b/e2e-test/__snapshots__/info.spec.ts.snap
@@ -2,7 +2,10 @@
 
 exports[`git-jira-branch info > info subcommand prints ticket info for current branch 1`] = `
 "[0;4m[0;1;4mGCJB-1[0;4m - E2E Test ticket with a fancy summary [0m
-[0;4m[0;1;4mTask[0;4m | [0;1;4mStatus:[0;4m To Do | [0;1;4mCreator:[0;4m Alexander Pankoff | [0;1;4mAssignee:[0;4m Alexander Pankoff[0m
+[0;4m[0;1;4mFeature[0;4m
+  | [0;1;4mStatus:[0;4m To Do
+  | [0;1;4mCreator:[0;4m Alexander Pankoff
+  | [0;1;4mAssignee:[0;4m Alexander Pankoff[0m
 
 *!!\\!IMPORTANT\\!!!*  - Do not modify this ticket without updating
 {{git-jira-branch}} E2E tests aswell!
@@ -31,7 +34,10 @@ valuable information whatsoever.
 
 exports[`git-jira-branch info > prints ticket info for given ticket 1`] = `
 "[0;4m[0;1;4mGCJB-1[0;4m - E2E Test ticket with a fancy summary [0m
-[0;4m[0;1;4mTask[0;4m | [0;1;4mStatus:[0;4m To Do | [0;1;4mCreator:[0;4m Alexander Pankoff | [0;1;4mAssignee:[0;4m Alexander Pankoff[0m
+[0;4m[0;1;4mFeature[0;4m
+  | [0;1;4mStatus:[0;4m To Do
+  | [0;1;4mCreator:[0;4m Alexander Pankoff
+  | [0;1;4mAssignee:[0;4m Alexander Pankoff[0m
 
 *!!\\!IMPORTANT\\!!!*  - Do not modify this ticket without updating
 {{git-jira-branch}} E2E tests aswell!

--- a/src/__snapshots__/cli.spec.ts.snap
+++ b/src/__snapshots__/cli.spec.ts.snap
@@ -50,28 +50,28 @@ $ git-jira-branch
 
 [0;1mCOMMANDS[0m
 
-  - create [(-b, --base text)] [(-r, --reset)] <jira-key>  
+  - create [(-b, --base text)] [(-t, --type text)] [(-r, --reset)] <jira-key>  
 Fetches the given Jira ticket and creates an aproriately named branch for it.
 The branch type (bug or feat) is determined by the ticket type. The branch name
 is based on the ticket summary.
 
-  - switch <jira-key>                                      
+  - switch <jira-key>                                                          
 Switches to an already existing branch that is associated with the given Jira
 ticket.
 
-  - delete [--force] <jira-key>                            
+  - delete [--force] <jira-key>                                                
 Deletes the branch associated with the given Jira Ticket.
 
-  - open [<jira-key>]                                      
+  - open [<jira-key>]                                                          
 Opens the given Jira ticket in your default browser. If no ticket is given the
 jira ticket for the current branch is opened.
 
-  - info [<jira-key>]                                      
+  - info [<jira-key>]                                                          
 Displays information for the given Jira ticket on your terminal. If no ticket is
 provided, it presents information for the Jira ticket associated with the
 current branch.
 
-  - list                                                   
+  - list                                                                       
 Lists all branches that appear to be associated with a Jira ticket.
 "
 `;

--- a/src/commands/create/create.command.ts
+++ b/src/commands/create/create.command.ts
@@ -13,6 +13,10 @@ export const create = pipe(
           Options.optional(Options.withAlias(Options.text('base'), 'b')),
           'Base revision to create the new branch from (a branch name, tag or commit SHA)',
         ),
+        type: Options.withDescription(
+          Options.optional(Options.withAlias(Options.text('type'), 't')),
+          `Type of branch to create (e.g. 'feat', 'fix', 'task')`,
+        ),
         reset: Options.withDescription(
           Options.withAlias(Options.boolean('reset'), 'r'),
           'Reset the branch if it already exists',
@@ -25,7 +29,12 @@ export const create = pipe(
     },
     ({options, jiraKey}) => {
       return Effect.flatMap(
-        gitCreateJiraBranch(jiraKey, options.baseBranch, options.reset),
+        gitCreateJiraBranch(
+          jiraKey,
+          options.type,
+          options.baseBranch,
+          options.reset,
+        ),
         compose(formatGitCreateJiraBranchResult, Console.log),
       );
     },

--- a/src/commands/create/create.handler.spec.ts
+++ b/src/commands/create/create.handler.spec.ts
@@ -28,7 +28,12 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('DUMMYAPP-123', Option.none(), false),
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.none(),
+            Option.none(),
+            false,
+          ),
           testLayer,
         ),
       );
@@ -78,7 +83,12 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('DUMMYAPP-123', Option.none(), false),
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.none(),
+            Option.none(),
+            false,
+          ),
           testLayer,
         ),
       );
@@ -109,6 +119,42 @@ describe('gitCreateJiraBranch', () => {
     }),
   );
 
+  live('should use custom type', () =>
+    Effect.gen(function* () {
+      mockAppConfigService.getAppConfig.mockReturnValue(
+        Effect.succeed({defaultJiraKeyPrefix: Option.none()}),
+      );
+      mockGitClient.createGitBranch.mockReturnValue(Effect.succeed(undefined));
+      mockJiraClient.getJiraIssue.mockReturnValue(
+        Effect.succeed(dummyJiraIssue),
+      );
+
+      yield* Effect.provide(
+        gitCreateJiraBranch(
+          'DUMMYAPP-123',
+          Option.some('custom'),
+          Option.none(),
+          false,
+        ),
+        testLayer,
+      ).pipe(
+        Effect.match({
+          onFailure: (e) =>
+            expect.unreachable(
+              `Should have created branch. Got error instead: ${e}`,
+            ),
+          onSuccess: (result) =>
+            expect(result).toMatchInlineSnapshot(`
+              {
+                "_tag": "CreatedBranch",
+                "branch": "custom/DUMMYAPP-123-dummy-isssue-summary",
+              }
+            `),
+        }),
+      );
+    }),
+  );
+
   live('should create feature branch from base branch', () =>
     Effect.gen(function* () {
       mockAppConfigService.getAppConfig.mockReturnValue(
@@ -121,7 +167,12 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('DUMMYAPP-123', Option.some('master'), false),
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.none(),
+            Option.some('master'),
+            false,
+          ),
           testLayer,
         ),
       );
@@ -173,7 +224,7 @@ describe('gitCreateJiraBranch', () => {
       );
 
       const result = yield* Effect.provide(
-        gitCreateJiraBranch('DUMMYAPP-123', Option.none(), true),
+        gitCreateJiraBranch('DUMMYAPP-123', Option.none(), Option.none(), true),
         testLayer,
       );
 
@@ -211,7 +262,7 @@ describe('gitCreateJiraBranch', () => {
       );
 
       const result = yield* Effect.provide(
-        gitCreateJiraBranch('DUMMYAPP-123', Option.none(), true),
+        gitCreateJiraBranch('DUMMYAPP-123', Option.none(), Option.none(), true),
         testLayer,
       );
 
@@ -250,7 +301,12 @@ describe('gitCreateJiraBranch', () => {
       );
 
       yield* Effect.provide(
-        gitCreateJiraBranch('DUMMYAPP-123', Option.none(), false).pipe(
+        gitCreateJiraBranch(
+          'DUMMYAPP-123',
+          Option.none(),
+          Option.none(),
+          false,
+        ).pipe(
           Effect.match({
             onSuccess: () => expect.unreachable('Should have failed'),
             onFailure: (e) =>
@@ -279,7 +335,7 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('123', Option.none(), false),
+          gitCreateJiraBranch('123', Option.none(), Option.none(), false),
           testLayer,
         ),
       );
@@ -324,7 +380,12 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('DUMMYAPP-123', Option.none(), false),
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.none(),
+            Option.none(),
+            false,
+          ),
           testLayer,
         ),
       );
@@ -373,7 +434,12 @@ describe('gitCreateJiraBranch', () => {
 
       const result = yield* Effect.either(
         Effect.provide(
-          gitCreateJiraBranch('DUMMYAPP-123', Option.none(), false),
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.none(),
+            Option.none(),
+            false,
+          ),
           testLayer,
         ),
       );


### PR DESCRIPTION
this introduces the `type` option to the create command. The given custom branch type takes precedence over the default branch type derived from the jira issue type.

---

feat(create-command): add support for task tickets and branches

maps branches with an issuetype name containing 'task' or 'aufgabe' to `task/` branches.