### PR TITLE
feat: add special case empty to CLI for type option

### DIFF
--- a/src/commands/create/create.command.ts
+++ b/src/commands/create/create.command.ts
@@ -15,7 +15,7 @@ export const create = pipe(
         ),
         type: Options.withDescription(
           Options.optional(Options.withAlias(Options.text('type'), 't')),
-          `Type of branch to create (e.g. 'feat', 'fix', 'task')`,
+          `Type of branch to create (e.g. 'feat', 'fix', 'task', 'empty'). Provide 'empty' will create a branch without a type prefix.`,
         ),
         reset: Options.withDescription(
           Options.withAlias(Options.boolean('reset'), 'r'),

--- a/src/commands/create/create.command.ts
+++ b/src/commands/create/create.command.ts
@@ -15,7 +15,7 @@ export const create = pipe(
         ),
         type: Options.withDescription(
           Options.optional(Options.withAlias(Options.text('type'), 't')),
-          `Type of branch to create (e.g. 'feat', 'fix', 'task', 'empty'). Provide 'empty' will create a branch without a type prefix.`,
+          `Type of branch to create (e.g. 'feat', 'fix', 'task'). Provide an empty string ("") to create a branch without a type prefix.`,
         ),
         reset: Options.withDescription(
           Options.withAlias(Options.boolean('reset'), 'r'),

--- a/src/commands/create/create.handler.spec.ts
+++ b/src/commands/create/create.handler.spec.ts
@@ -484,7 +484,7 @@ describe('gitCreateJiraBranch', () => {
         Effect.provide(
           gitCreateJiraBranch(
             'DUMMYAPP-123',
-            Option.some('empty'),
+            Option.some(''),
             Option.none(),
             false,
           ),

--- a/src/commands/create/create.handler.spec.ts
+++ b/src/commands/create/create.handler.spec.ts
@@ -469,4 +469,51 @@ describe('gitCreateJiraBranch', () => {
       expect(mockGitClient.createGitBranchFrom).not.toHaveBeenCalled();
     }),
   );
+
+  live('should create branch with no type', () =>
+    Effect.gen(function* () {
+      mockAppConfigService.getAppConfig.mockReturnValue(
+        Effect.succeed({defaultJiraKeyPrefix: Option.none()}),
+      );
+      mockGitClient.createGitBranch.mockReturnValue(Effect.succeed(undefined));
+      mockJiraClient.getJiraIssue.mockReturnValue(
+        Effect.succeed(dummyJiraIssue),
+      );
+
+      const result = yield* Effect.either(
+        Effect.provide(
+          gitCreateJiraBranch(
+            'DUMMYAPP-123',
+            Option.some('empty'),
+            Option.none(),
+            false,
+          ),
+          testLayer,
+        ),
+      );
+
+      Either.match(result, {
+        onLeft: (e) =>
+          expect.unreachable(
+            `Should have created branch. Got error instead: ${e}`,
+          ),
+        onRight: (result) =>
+          expect(result).toMatchInlineSnapshot(`
+          {
+            "_tag": "CreatedBranch",
+            "branch": "DUMMYAPP-123-dummy-isssue-summary",
+          }
+        `),
+      });
+
+      expect(mockAppConfigService.getAppConfig).toHaveBeenCalledTimes(1);
+      expect(mockJiraClient.getJiraIssue).toHaveBeenCalledTimes(1);
+      expect(mockJiraClient.getJiraIssue).toHaveBeenCalledWith('DUMMYAPP-123');
+      expect(mockGitClient.createGitBranch).toHaveBeenCalledTimes(1);
+      expect(mockGitClient.createGitBranch).toHaveBeenCalledWith(
+        'DUMMYAPP-123-dummy-isssue-summary',
+        false,
+      );
+    }),
+  );
 });

--- a/src/commands/create/create.handler.ts
+++ b/src/commands/create/create.handler.ts
@@ -67,7 +67,8 @@ const jiraIssueToBranchName = (
   const branchtype = Option.getOrElse(type, () =>
     jiraIssuetypeBranchtype(issue.fields.issuetype),
   );
-  return `${branchtype}/${issue.key}-${slugify(issue.fields.summary)}`;
+  const prefix = branchtype === 'empty' ? '' : `${branchtype}/`;
+  return `${prefix}${issue.key}-${slugify(issue.fields.summary)}`;
 };
 
 const jiraIssuetypeBranchtype = (issuetype: JiraIssuetype): string => {

--- a/src/commands/create/create.handler.ts
+++ b/src/commands/create/create.handler.ts
@@ -67,7 +67,7 @@ const jiraIssueToBranchName = (
   const branchtype = Option.getOrElse(type, () =>
     jiraIssuetypeBranchtype(issue.fields.issuetype),
   );
-  const prefix = branchtype === 'empty' ? '' : `${branchtype}/`;
+  const prefix = branchtype.length === 0 ? '' : `${branchtype}/`;
   return `${prefix}${issue.key}-${slugify(issue.fields.summary)}`;
 };
 


### PR DESCRIPTION
Resolving #522 for an "empty" type `-t` option. 

I used the literal "empty" as the parameter since I didn't want to change the default behavior for leaving `-t` out. Perhaps that can be adjusted in the future.

Let me know if the test and changes are to your liking! I have not contributed to a js project...ever, lol.