### PR TITLE
test(e2e): build dist and run locally; allow CI override

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -36,4 +36,4 @@ jobs:
           JIRA_USER_EMAIL: ${{ secrets.GCJB_USER_EMAIL }}
           JIRA_API_URL: ${{ vars.GCJB_JIRA_API_URL }}
           JIRA_KEY_PREFIX: ${{ vars.GCJB_JIRA_KEY_PREFIX }}
-        run: pnpm e2e-test
+        run: pnpm e2e-test:ci

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ $ git jira-branch create MYAPP-1234
   - [`wizard` mode](#wizardmode)
 - [Setup](#Setup)
   - [Install](#Install)
-  - [Configuration](#Configuration)
+- [Configuration](#Configuration)
     - [For Jira Cloud](#ForJiraCloud)
     - [For Jira Data Center](#ForJiraDataCenter)
   - [Setup shell completions](#Setupshellcompletions)
+- [Development](#Development)
+  - [Run E2E tests against local sources](#RunE2Etestsagainstlocalsources)
 - [Contributors](#Contributors)
 - [Technologies used](#Technologiesused)
 - [License](#License)
@@ -201,6 +203,19 @@ git-jira-branch --completions bash > ~/.git-jira-branch-bash-completions
 echo "source \$HOME/.git-jira-branch-bash-completions" >> ~/.bashrc
 source ~/.bashrc
 ```
+
+## <a name='Development'></a>Development
+
+### <a name='RunE2Etestsagainstlocalsources'></a>Run E2E tests against local sources
+
+Running `pnpm e2e-test` locally type-checks, rebuilds the CLI, and then executes
+the freshly built binary (`node dist/main.js`) against the fixtures, so no extra
+setup is required.
+
+In CI you can call `pnpm e2e-test:ci`, which defaults to
+`GIT_JB_BIN=git-jira-branch` unless you override the variable before invoking
+the command. This lets you choose whether the suite exercises the published
+package or a specific binary path.
 
 ## <a name='Contributors'></a>Contributors
 

--- a/package.json
+++ b/package.json
@@ -41,9 +41,10 @@
     "test:watch": "vitest --exclude=e2e-test",
     "test:type-check": "tsc -p src/tsconfig.test.json --noEmit",
     "pretest": "pnpm test:type-check",
-    "e2e-test": "vitest run --exclude=src",
+    "e2e-test": "pnpm e2e-test:local",
+    "e2e-test:local": "pnpm e2e-test:type-check && pnpm build && vitest run --exclude=src",
+    "e2e-test:ci": "pnpm e2e-test:type-check && GIT_JB_BIN=${GIT_JB_BIN:-git-jira-branch} vitest run --exclude=src",
     "e2e-test:type-check": "tsc -p e2e-test/tsconfig.e2e-test.json",
-    "pree2e-test": "pnpm e2e-test:type-check",
     "lint": "biome check .",
     "lint:fix": "biome check . --write"
   },


### PR DESCRIPTION
- run e2e tests locally against "node dist/main.js" after type-check + build
- add new command `pnpm e2e-test:ci` (defaults to `git-jira-branch`, can be overridden with `GIT_JB_BIN`) and update the CI workflow
- normalise error messages so snapshots still reference `git-jira-branch`
- document local vs CI usage in README