### PR TITLE
ci: ignore major updates for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
         dependency-type: 'production'
       development-dependencies:
         dependency-type: 'development'
+    ignore:
+      - dependency-name: '@types/node'
+        update-types:
+          - 'version-update:semver-major'
     schedule:
       interval: 'daily'
       time: '09:00'


### PR DESCRIPTION
this will be bumped manually when support for the node version is dropped and updated to the minimum supported version.